### PR TITLE
check_frame_and_element_fluent_interface_example uses padding bounds …

### DIFF
--- a/examples/check_frame_and_element_fluent_interface_example.rb
+++ b/examples/check_frame_and_element_fluent_interface_example.rb
@@ -24,11 +24,15 @@ RSpec.describe 'Check frame and element example', :type => :feature, :js => true
               viewport_size: { width: 800, height: 600 }
 
     visit 'https://astappev.github.io/test-html-pages/'
-    target = Applitools::Selenium::Target.window.fully.ignore(Applitools::Region.new(55, 60, 90, 90))
+    target = Applitools::Selenium::Target.window.fully.ignore(
+      Applitools::Region.new(55, 60, 90, 90), Applitools::PaddingBounds.new(10, 12, 14, 16)
+    )
     eyes.check('Whole page', target)
     target = Applitools::Selenium::Target.region(eyes.driver.find_element(:id, 'overflowing-div')).fully
     eyes.check 'Overflowed region', target
-    target = Applitools::Selenium::Target.window.frame('frame1').fully.floating(:id, 'inner-frame-div', 10, 10, 10, 10)
+    target = Applitools::Selenium::Target.window.frame('frame1').fully.floating(
+      :id, 'inner-frame-div', 10, 10, 10, 10, Applitools::PaddingBounds.new(10, 12, 14, 16)
+    )
     eyes.check('', target)
     target = target.region(:id, 'inner-frame-div').fully.match_level(:exact) # Region in frame..
     eyes.check('Inner frame div', target)


### PR DESCRIPTION
…for ignore and floating