### PR TITLE
fixed SDKs Trello Cards 1614 and 1624

### DIFF
--- a/lib/applitools/selenium/css_parser/find_embedded_resources.rb
+++ b/lib/applitools/selenium/css_parser/find_embedded_resources.rb
@@ -49,7 +49,7 @@ module Applitools
         end
 
         def fetch_urls(nodes)
-          nodes.map { |n| url(n) }.flatten.compact
+          nodes.map { |n| url(n) }.flatten.compact rescue []
         end
 
         def import_rules
@@ -83,9 +83,12 @@ module Applitools
             @nodes_by_type[:font_face_rules] << n if n[:node] == :at_rule && n[:name] == 'font-face'
             @nodes_by_type[:images_rules] << n if n[:node] == :style_rule
           end
-          @nodes_by_type[:images_rules].map! { |n| n[:children] }.flatten!
-          @nodes_by_type[:images_rules] = @nodes_by_type[:images_rules].select do |n|
-            n[:node] == :property && (n[:name] == 'background' || n[:name] == 'background-image')
+
+          unless @nodes_by_type[:images_rules].nil?
+            @nodes_by_type[:images_rules].map! { |n| n[:children] }.flatten!
+            @nodes_by_type[:images_rules] = @nodes_by_type[:images_rules].select do |n|
+              n[:node] == :property && (n[:name] == 'background' || n[:name] == 'background-image')
+            end
           end
           @nodes_by_type
         end

--- a/lib/applitools/selenium/dom_capture/dom_capture.rb
+++ b/lib/applitools/selenium/dom_capture/dom_capture.rb
@@ -58,7 +58,7 @@ module Applitools
         result = replace(separators['iframeStartToken'], separators['iframeEndToken'], data.first, frame_data)
         css_data = fetch_css_files(missing_css_list, server_connector)
         replace(separators['cssStartToken'], separators['cssEndToken'], result, css_data)
-      rescue StandardError
+      rescue StandardError => e
         logger.error(e.class)
         logger.error(e.message)
         logger.error(e)


### PR DESCRIPTION
Fixed issues for: 
https://trello.com/c/wQ9IbJCk/1624-ruby-selenium-checking-iframe-throws-error
https://trello.com/c/Ym98t1GP/1614-ruby-gap-issue-capturing-page-on-the-visual-grid
* @nodes_by_type[:images_rules] can sometimes come back as nil. Perhaps there is a fix upstream from here but this is the way I got it working locally. 