### PR TITLE
update to the scripts to use ID

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,8 +22,8 @@
     "ruby:create": "mkdir -p ./coverage_tests/spec/coverage/generic && cd coverage_tests && coverage-tests create-tests --path ./configuration",
     "ruby:create:noskip": "mkdir -p ./coverage_tests/spec/coverage/generic && cd coverage_tests && coverage-tests create-tests --path ./configuration -a",
     "ruby:report": "[ \"$TEST_REPORT_SANDBOX\" = \"False\" ] && yarn ruby:report:prod || yarn ruby:report:sandbox ",
-    "ruby:report:sandbox": "cd coverage_tests && coverage-tests process-report --path ./configuration",
-    "ruby:report:prod": "cd coverage_tests && coverage-tests process-report --path ./configuration --send-report prod",
+    "ruby:report:sandbox": "cd coverage_tests && coverage-tests process-report --path ./configuration$( [ -z $TRAVIS_COMMIT ] || echo \" --reportId $TRAVIS_COMMIT\" )",
+    "ruby:report:prod": "cd coverage_tests && coverage-tests process-report --path ./configuration --reportId $TRAVIS_COMMIT --send-report prod",
     "ruby:run": "cd coverage_tests && APPLITOOLS_BATCH_NAME='Ruby Coverage Tests' APPLITOOLS_BATCH_ID=$(uuidgen) bundle exec rspec spec/coverage/generic",
     "ruby:run:debug": "cd coverage_tests && APPLITOOLS_BATCH_NAME='Ruby Coverage Tests' APPLITOOLS_BATCH_ID=$(uuidgen) APPLITOOLS_SHOW_LOGS='true' bundle exec rspec spec/coverage/generic",
     "ruby:run:parallel": "cd coverage_tests && APPLITOOLS_BATCH_NAME='Ruby Coverage Tests' APPLITOOLS_BATCH_ID=$(uuidgen) bundle exec parallel_rspec -n 6 spec/coverage/generic",
@@ -33,7 +33,7 @@
     "docker:stop": "docker stop selenium && docker rm selenium"
   },
   "dependencies": {
-    "@applitools/sdk-coverage-tests": "1.0.8",
+    "@applitools/sdk-coverage-tests": "1.0.9",
     "junit-merge": "^2.0.0",
     "@typescript-eslint/parser": "^2.14.0",
     "typescript": "^3.7.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,10 +2,10 @@
 # yarn lockfile v1
 
 
-"@applitools/sdk-coverage-tests@1.0.8":
-  version "1.0.8"
-  resolved "https://registry.yarnpkg.com/@applitools/sdk-coverage-tests/-/sdk-coverage-tests-1.0.8.tgz#124add43425a96c60f209664ceb98f197bf700d1"
-  integrity sha512-hgiMfm63TmwVHnR6otmiBoweOdGTDbWyBgTYcLseubqcTd9o1FM9LTIgYFFMEUK9ND96zCvRQuBK8bneJJOZZQ==
+"@applitools/sdk-coverage-tests@1.0.9":
+  version "1.0.9"
+  resolved "https://registry.yarnpkg.com/@applitools/sdk-coverage-tests/-/sdk-coverage-tests-1.0.9.tgz#a274bc04ece15bd5cfe103f0e896986f981f060b"
+  integrity sha512-pC5vy33b8kMgWKGI0kQwn6wrIKTuGBWCZLnKwXXpAOdXkRTbif/ab13U/O/cAKPTFcikPLJEpQk8lo4jUDV8pA==
   dependencies:
     chai "^4.2.0"
     chai-as-promised "^7.1.1"


### PR DESCRIPTION
ruby:report:sandbox conditionally apply ID if env variable TRAVIS_COMMIT is set, otherwise don't send an ID (in this case ID will be generated on the server side).
ruby:report:prod always use env variable TRAVIS_COMMIT (expected to run only on travis during release event)