### PR TITLE
Add setting of branch name for generic tests if it present in overrides' config

### DIFF
--- a/coverage_tests/configuration/index.js
+++ b/coverage_tests/configuration/index.js
@@ -1,7 +1,7 @@
 module.exports = {
   name: 'eyes_selenium_ruby',
   emitter: 'https://raw.githubusercontent.com/applitools/sdk.coverage.tests/master/ruby/initialize.js',
-  overrides: 'https://raw.githubusercontent.com/applitools/sdk.coverage.tests/remove_skip_for_Ruby2/ruby/overrides.js',
+  overrides: 'https://raw.githubusercontent.com/applitools/sdk.coverage.tests/master/ruby/overrides.js',
   template: 'https://raw.githubusercontent.com/applitools/sdk.coverage.tests/master/ruby/template.hbs',
   ext: '_spec.rb',
   outPath: './spec/coverage/generic'

--- a/coverage_tests/configuration/index.js
+++ b/coverage_tests/configuration/index.js
@@ -1,7 +1,7 @@
 module.exports = {
   name: 'eyes_selenium_ruby',
   emitter: 'https://raw.githubusercontent.com/applitools/sdk.coverage.tests/master/ruby/initialize.js',
-  overrides: 'https://raw.githubusercontent.com/applitools/sdk.coverage.tests/master/ruby/overrides.js',
+  overrides: 'https://raw.githubusercontent.com/applitools/sdk.coverage.tests/remove_skip_for_Ruby2/ruby/overrides.js',
   template: 'https://raw.githubusercontent.com/applitools/sdk.coverage.tests/master/ruby/template.hbs',
   ext: '_spec.rb',
   outPath: './spec/coverage/generic'

--- a/coverage_tests/spec/selenium_helper.rb
+++ b/coverage_tests/spec/selenium_helper.rb
@@ -48,6 +48,7 @@ RSpec.configure do |config|
       @eyes.browsers_info = browser_info
     end
     @eyes.parent_branch_name = args[:parent_branch_name] if args.key? :parent_branch_name
+    @eyes.branch_name = args[:branch_name] if args.key? :branch_name
     @eyes.hide_scrollbars = args[:hide_scrollbars] if args.key? :hide_scrollbars
     @eyes.disabled = args[:is_disabled] if args.key? :is_disabled
     if args.key? :default_match_settings


### PR DESCRIPTION
Current setting of branch name in eyes(args) isn't enough because if branch name present in overrides' config it is added as parameter in eyes_config(args) call. Successful run - https://travis-ci.com/github/applitools/eyes.sdk.ruby/builds/220430272