### PR TITLE
Updates options for emulator tests

### DIFF
--- a/coverage_tests/configuration/index.js
+++ b/coverage_tests/configuration/index.js
@@ -1,7 +1,7 @@
 module.exports = {
   name: 'eyes_selenium_ruby',
-  emitter: 'https://raw.githubusercontent.com/applitools/sdk.coverage.tests/master/ruby/initialize.js',
-  overrides: 'https://raw.githubusercontent.com/applitools/sdk.coverage.tests/master/ruby/overrides.js',
+  emitter: 'https://raw.githubusercontent.com/applitools/sdk.coverage.tests/remove_skip_for_Ruby3/ruby/initialize.js',
+  overrides: 'https://raw.githubusercontent.com/applitools/sdk.coverage.tests/remove_skip_for_Ruby3/ruby/overrides.js',
   template: 'https://raw.githubusercontent.com/applitools/sdk.coverage.tests/master/ruby/template.hbs',
   ext: '_spec.rb',
   outPath: './spec/coverage/generic'

--- a/coverage_tests/spec/driver_build.rb
+++ b/coverage_tests/spec/driver_build.rb
@@ -100,7 +100,7 @@ DEVICES = {
     'Android 8.0 Chrome Emulator' => {
       capabilities: {
         browserName: 'chrome',
-          'goog:chromeOptions': {
+          BROWSER_OPTIONS_NAME['chrome'] => {
             mobileEmulation: {
               deviceMetrics: {width: 384, height: 512, pixelRatio: 2},
                   userAgent:


### PR DESCRIPTION
Updates options for emulator tests. Now generic tests  'check window fully on android chrome emulator on...' can be run.
Successfull run - https://travis-ci.com/github/applitools/eyes.sdk.ruby/builds/225436490